### PR TITLE
Catch unfixable jscs errors in gulp. Update build assets.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require( "gulp" );
+var gutil = require( "gulp-util" );
 var sourcemaps = require( "gulp-sourcemaps" );
 var rename = require( "gulp-rename" );
 var header = require( "gulp-header" );
@@ -99,6 +100,10 @@ gulp.task( "format", [ "build:es6", "build:es5" ], function() {
 			configPath: ".jscsrc",
 			fix: true
 		} ) )
+		.on( "error", function( error ) {
+			gutil.log( gutil.colors.red( error.message ) );
+			this.end();
+		} )
 		.pipe( gulpChanged( ".", { hasChanged: gulpChanged.compareSha1Digest } ) )
 		.pipe( gulp.dest( "." ) );
 } );

--- a/lib/lux-autohost-es6.js
+++ b/lib/lux-autohost-es6.js
@@ -1,7 +1,7 @@
 /**
  * lux-autohost - Action Creator API for submitting logging & metrics to autohost from lux.js apps.
  * Author: Jim Cowart
- * Version: v0.0.1
+ * Version: v0.0.2
  * Url: https://github.com/LeanKit-Labs/lux-autohost
  * License(s): MIT Copyright (c) 2015 LeanKit
  */

--- a/lib/lux-autohost.js
+++ b/lib/lux-autohost.js
@@ -1,7 +1,7 @@
 /**
  * lux-autohost - Action Creator API for submitting logging & metrics to autohost from lux.js apps.
  * Author: Jim Cowart
- * Version: v0.0.1
+ * Version: v0.0.2
  * Url: https://github.com/LeanKit-Labs/lux-autohost
  * License(s): MIT Copyright (c) 2015 LeanKit
  */

--- a/lib/lux-autohost.min.js
+++ b/lib/lux-autohost.min.js
@@ -1,7 +1,7 @@
 /**
  * lux-autohost - Action Creator API for submitting logging & metrics to autohost from lux.js apps.
  * Author: Jim Cowart
- * Version: v0.0.1
+ * Version: v0.0.2
  * Url: https://github.com/LeanKit-Labs/lux-autohost
  * License(s): MIT Copyright (c) 2015 LeanKit
  */

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gulp-sourcemaps": "^1.1.1",
     "gulp-spawn-mocha": "^2.0.1",
     "gulp-uglify": "^1.0.1",
+    "gulp-util": "~3.0.5",
     "imports-loader": "^0.6.3",
     "istanbul": "^0.3.2",
     "jsdom": "^2.0.0",


### PR DESCRIPTION
- add error catch to format task
- build assets were not updated with current version number
